### PR TITLE
Fix `Result` type

### DIFF
--- a/.changeset/late-deers-report.md
+++ b/.changeset/late-deers-report.md
@@ -1,0 +1,5 @@
+---
+"@wunderwerk/ts-functional": patch
+---
+
+Fix type narrowing of `Result` type.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-esbuild": "^5.0.0",
     "ts-node": "^10.9.1",
+    "tsd": "^0.28.1",
     "typescript": "^5.0.4"
   },
   "scripts": {
@@ -32,9 +33,9 @@
     "lint": "eslint --ext .ts src --max-warnings 0",
     "format:check": "prettier --check '**/*.{ts,tsx}'",
     "format:write": "prettier --write '**/*.{ts,tsx}'",
-    "test": "NODE_NO_WARNINGS=1 ava",
+    "test": "NODE_NO_WARNINGS=1 ava && tsd -t dist/results/index.d.ts --files tests/**/*.test-d.ts",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",
-    "check-all": "pnpm run '/(build|lint|test|typecheck)/'",
+    "check-all": "pnpm run build && pnpm run '/(lint|test|typecheck)/'",
     "version-package": "pnpm run check-all && changeset version",
     "publish-package": "pnpm run check-all && changeset publish",
     "prepare": "husky install"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ specifiers:
   rollup-plugin-dts: ^5.3.0
   rollup-plugin-esbuild: ^5.0.0
   ts-node: ^10.9.1
+  tsd: ^0.28.1
   typescript: ^5.0.4
 
 devDependencies:
@@ -48,6 +49,7 @@ devDependencies:
   rollup-plugin-dts: 5.3.0_dqoqy63ndela2j7oq3l4jxkjsa
   rollup-plugin-esbuild: 5.0.0_524qciktagxrmdvar7sqernw7q
   ts-node: 10.9.1_4nchvo4eogszfxemdbko76zc7a
+  tsd: 0.28.1
   typescript: 5.0.4
 
 packages:
@@ -935,6 +937,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /@jest/schemas/29.4.3:
+    resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.25.24
+    dev: true
+
   /@jridgewell/gen-mapping/0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -1049,6 +1058,10 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.20.4
+    dev: true
+
+  /@sinclair/typebox/0.25.24:
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
     dev: true
 
   /@swc/core-darwin-arm64/1.3.51:
@@ -1177,6 +1190,17 @@ packages:
 
   /@tsconfig/node16/1.0.3:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+    dev: true
+
+  /@tsd/typescript/5.0.4:
+    resolution: {integrity: sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==}
+    dev: true
+
+  /@types/eslint/7.29.0:
+    resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
+    dependencies:
+      '@types/estree': 1.0.0
+      '@types/json-schema': 7.0.11
     dev: true
 
   /@types/estree/1.0.0:
@@ -1434,6 +1458,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /ansi-escapes/4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
+    dev: true
+
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1456,6 +1487,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /ansi-styles/5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
     dev: true
 
   /ansi-styles/6.2.1:
@@ -2113,6 +2149,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /diff-sequences/29.4.3:
+    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -2317,6 +2358,20 @@ packages:
       eslint: 8.38.0
     dev: true
 
+  /eslint-formatter-pretty/4.1.0:
+    resolution: {integrity: sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/eslint': 7.29.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      eslint-rule-docs: 1.1.235
+      log-symbols: 4.1.0
+      plur: 4.0.0
+      string-width: 4.2.3
+      supports-hyperlinks: 2.3.0
+    dev: true
+
   /eslint-import-resolver-node/0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
@@ -2444,6 +2499,10 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
     optional: true
+
+  /eslint-rule-docs/1.1.235:
+    resolution: {integrity: sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==}
+    dev: true
 
   /eslint-scope/5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -3232,6 +3291,11 @@ packages:
       has-tostringtag: 1.0.0
     dev: true
 
+  /is-unicode-supported/0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+    dev: true
+
   /is-unicode-supported/1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
@@ -3276,6 +3340,21 @@ packages:
 
   /javascript-natural-sort/0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+    dev: true
+
+  /jest-diff/29.5.0:
+    resolution: {integrity: sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.4.3
+      jest-get-type: 29.4.3
+      pretty-format: 29.5.0
+    dev: true
+
+  /jest-get-type/29.4.3:
+    resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /joycon/3.1.1:
@@ -3493,6 +3572,14 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
+  /log-symbols/4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+    dev: true
+
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3601,6 +3688,24 @@ packages:
     dependencies:
       '@types/minimist': 1.2.2
       camelcase-keys: 6.2.2
+      decamelize-keys: 1.1.1
+      hard-rejection: 2.1.0
+      minimist-options: 4.1.0
+      normalize-package-data: 3.0.3
+      read-pkg-up: 7.0.1
+      redent: 3.0.0
+      trim-newlines: 3.0.1
+      type-fest: 0.18.1
+      yargs-parser: 20.2.9
+    dev: true
+
+  /meow/9.0.0:
+    resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/minimist': 1.2.2
+      camelcase-keys: 6.2.2
+      decamelize: 1.2.0
       decamelize-keys: 1.1.1
       hard-rejection: 2.1.0
       minimist-options: 4.1.0
@@ -3995,6 +4100,13 @@ packages:
       find-up: 4.1.0
     dev: true
 
+  /plur/4.0.0:
+    resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==}
+    engines: {node: '>=10'}
+    dependencies:
+      irregular-plurals: 3.5.0
+    dev: true
+
   /plur/5.1.0:
     resolution: {integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4021,6 +4133,15 @@ packages:
     resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    dev: true
+
+  /pretty-format/29.5.0:
+    resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.4.3
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
     dev: true
 
   /pretty-ms/8.0.0:
@@ -4066,6 +4187,10 @@ packages:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: true
     optional: true
+
+  /react-is/18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -4543,6 +4668,14 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /supports-hyperlinks/2.3.0:
+    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -4691,6 +4824,20 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tsd/0.28.1:
+    resolution: {integrity: sha512-FeYrfJ05QgEMW/qOukNCr4fAJHww4SaKnivAXRv4g5kj4FeLpNV7zH4dorzB9zAfVX4wmA7zWu/wQf7kkcvfbw==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+    dependencies:
+      '@tsd/typescript': 5.0.4
+      eslint-formatter-pretty: 4.1.0
+      globby: 11.1.0
+      jest-diff: 29.5.0
+      meow: 9.0.0
+      path-exists: 4.0.0
+      read-pkg-up: 7.0.1
+    dev: true
+
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
@@ -4738,6 +4885,11 @@ packages:
 
   /type-fest/0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest/0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
     dev: true
 

--- a/src/results/index.ts
+++ b/src/results/index.ts
@@ -6,9 +6,10 @@ import { toString } from "../utils/index.js";
  * @template T - The type of the value in the Ok case.
  * @template TError - The type of the value in the Err case.
  */
-interface Result<T, TError> {
+interface BaseResult<T, TError> {
   readonly ok: boolean;
   readonly err: boolean;
+  readonly val: T | TError;
 
   /**
    * Get the value from the Ok case, or throw an error if the Result is an Err.
@@ -46,7 +47,7 @@ interface Result<T, TError> {
  *
  * @template TError - Type of the error.
  */
-export class ResultErr<TError> implements Result<never, TError> {
+export class ResultErr<TError> implements BaseResult<never, TError> {
   readonly ok = false;
   readonly err = true;
   readonly val: TError;
@@ -86,7 +87,7 @@ export class ResultErr<TError> implements Result<never, TError> {
  *
  * @template T - Type of the value.
  */
-export class ResultOk<T> implements Result<T, never> {
+export class ResultOk<T> implements BaseResult<T, never> {
   readonly ok = true;
   readonly err = false;
   readonly val: T;
@@ -143,7 +144,7 @@ export const Err = <TError>(val: TError) => new ResultErr(val);
  */
 export const wrap = <T, TError = unknown>(
   operation: () => T
-): Result<T, TError> => {
+): BaseResult<T, TError> => {
   try {
     return Ok(operation());
   } catch (err) {
@@ -159,7 +160,7 @@ export const wrap = <T, TError = unknown>(
  */
 export const wrapAsync = async <T, TError = unknown>(
   operation: () => Promise<T>
-): Promise<Result<T, TError>> => {
+): Promise<BaseResult<T, TError>> => {
   try {
     return Ok(await operation());
   } catch (e) {
@@ -176,3 +177,5 @@ export const Result = {
   wrap,
   wrapAsync,
 };
+
+export type Result<T, TError> = ResultOk<T> | ResultErr<TError>;

--- a/tests/results.test-d.ts
+++ b/tests/results.test-d.ts
@@ -28,20 +28,20 @@ function testTypeNarrowing() {
 function testExpect() {
   const result = divide(1, 0);
 
-  expectType<number>(result.expect('Expected number'));
+  expectType<number>(result.expect("Expected number"));
 
   if (result.err) {
-    expectType<never>(result.expect('Expected number'));
+    expectType<never>(result.expect("Expected number"));
   }
 }
 
 function testExpectErr() {
   const result = divide(1, 0);
 
-  expectType<string>(result.expectErr('Expected error'));
+  expectType<string>(result.expectErr("Expected error"));
 
   if (result.ok) {
-    expectType<never>(result.expectErr('Expected error'));
+    expectType<never>(result.expectErr("Expected error"));
   }
 }
 

--- a/tests/results.test-d.ts
+++ b/tests/results.test-d.ts
@@ -1,0 +1,66 @@
+import { Result } from "../src/results/index.js";
+import { expectType } from "tsd";
+
+function divide(a: number, b: number): Result<number, string> {
+  if (b === 0) {
+    return Result.Err("Cannot divide by 0");
+  }
+
+  return Result.Ok(a / b);
+}
+
+function testTypeNarrowing() {
+  const result = divide(1, 0);
+
+  expectType<Result<number, string>>(result);
+
+  if (result.err) {
+    expectType<true>(result.err);
+    expectType<string>(result.val);
+
+    throw new Error(result.val);
+  }
+
+  expectType<true>(result.ok);
+  expectType<number>(result.val);
+}
+
+function testExpect() {
+  const result = divide(1, 0);
+
+  expectType<number>(result.expect('Expected number'));
+
+  if (result.err) {
+    expectType<never>(result.expect('Expected number'));
+  }
+}
+
+function testExpectErr() {
+  const result = divide(1, 0);
+
+  expectType<string>(result.expectErr('Expected error'));
+
+  if (result.ok) {
+    expectType<never>(result.expectErr('Expected error'));
+  }
+}
+
+function testUnwrap() {
+  const result = divide(1, 0);
+
+  expectType<number>(result.unwrap());
+
+  if (result.err) {
+    expectType<never>(result.unwrap());
+  }
+}
+
+function testUnwrapOr() {
+  const result = divide(1, 0);
+
+  expectType<number>(result.unwrapOr(0));
+
+  if (result.err) {
+    expectType<0>(result.unwrapOr(0));
+  }
+}


### PR DESCRIPTION
Make type narrowing for the `Result` type work.

- [x] Add working type definition for `Result`
- [x] Add tests for TypeScript type narrowing 

Fixes #4.